### PR TITLE
[SPARK-20599][SS]ConsoleSink should work with write (batch)

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -473,6 +473,8 @@ case class DataSource(
     providingClass.newInstance() match {
       case dataSource: CreatableRelationProvider =>
         dataSource.createRelation(sparkSession.sqlContext, mode, caseInsensitiveOptions, data)
+      case dataSource: ConsoleSinkProvider =>
+        data.show(data.count().toInt, false)
       case format: FileFormat =>
         writeInFileFormat(format, mode, data)
       case _ =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently，Console Sink does not support with write batch, that is you write the Dataset/DataFrame with format console.

In this PR, we add a  check whether it is ConsoleSinkProvider. if yes, we will display the rows of the dataset
instead of leading the Runtime Exception.

## How was this patch tested?
 spark
      .read
      .json(path)
      .write
      .format("console")
      .save()